### PR TITLE
Change PHPUnit_Framework_Assert to use forward-compatibly PHPUnit\Fra…

### DIFF
--- a/tests/PyzTest/Zed/Console/Console/ConsoleCest.php
+++ b/tests/PyzTest/Zed/Console/Console/ConsoleCest.php
@@ -7,7 +7,7 @@
 
 namespace PyzTest\Zed\Console\Console;
 
-use PHPUnit_Framework_Assert;
+use PHPUnit\Framework\Assert;
 use PyzTest\Zed\Console\ConsoleConsoleTester;
 
 /**
@@ -31,7 +31,7 @@ class ConsoleCest
         $i->wantTo('See that console is running');
 
         $output = $i->runConsoleApplication();
-        PHPUnit_Framework_Assert::assertRegExp('/Store/', $output);
-        PHPUnit_Framework_Assert::assertRegExp('/Environment/', $output);
+        Assert::assertRegExp('/Store/', $output);
+        Assert::assertRegExp('/Environment/', $output);
     }
 }


### PR DESCRIPTION
PHPUnit 5.7.0 added  "`PHPUnit\Framework\Assert` as an alias for `PHPUnit_Framework_Assert` for forward compatibility."

This PR allows the code to work on a newer version of codeception. The same changes should be made in core spryker modules. I see the old style assertion is used in 

`SprykerTest\Shared\Testify\Helper\SeeHelper`