### PR TITLE
Removing early exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,6 @@ sudo: required
 
 before_install:
   - phpenv config-add config/Shared/ci/travis/travis.php.ini
-  - if [[ $VALIDATION != 1 && $ON_EVENTS != *$TRAVIS_EVENT_TYPE* ]]; then exit; fi
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - phpenv config-rm xdebug.ini
   - if [[ $DB == 'mysql' ]]; then chmod +x ./config/Shared/ci/travis/mysql/* ; fi


### PR DESCRIPTION
Looks like exit works differently on travis .org and .com

#### Overview

- Ticket: URL_HERE

###### Optional

Reference all core PRs for auto-link back-references.

Core PRs
- URL_HERE

###### Change log

{Relevant changes for project level go here. Those will be copied to the release log for suite if necessary.}
