### PR TITLE
Upgrade dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -820,7 +820,6 @@
     "myclabs/deep-copy": "^1.8.1",
     "composer/package-versions-deprecated": "^1.8.0",
     "pdepend/pdepend": "^2.2.4",
-    "phpmd/phpmd": "~2.7.0",
     "phpunit/phpunit": "^8.0.0",
     "roave/better-reflection": "^3.3.0",
     "sebastian/object-enumerator": "^3.0.3",


### PR DESCRIPTION
Avoid

> Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in /home/travis/build/spryker-shop/suite/vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 575
PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /home/travis/build/spryker-shop/suite/vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 575