### PR TITLE
Make jetbrains dependendy for PHP8 more verbose.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -991,6 +991,7 @@
         "doctrine/lexer": "^1.0.2",
         "filp/whoops": "^2.7",
         "fzaninotto/faker": "^1.6.0",
+        "jetbrains/phpstorm-stubs":  "dev-master",
         "pdepend/pdepend": "^2.2.4",
         "phpstan/phpstan": "0.12.98",
         "phpunit/phpunit": "^9.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6db1a9a0891a9aaafaacd1b129aa6d52",
+    "content-hash": "2879a25bf29f52003403f0f05d9d32c4",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.202.0",
+            "version": "3.202.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "da75964c7ca13755337ddd63a4b643cb43f0ead0"
+                "reference": "59ee4506f7f2b2f0f1de4b60ab2c1b8294c7afcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/da75964c7ca13755337ddd63a4b643cb43f0ead0",
-                "reference": "da75964c7ca13755337ddd63a4b643cb43f0ead0",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/59ee4506f7f2b2f0f1de4b60ab2c1b8294c7afcd",
+                "reference": "59ee4506f7f2b2f0f1de4b60ab2c1b8294c7afcd",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.202.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.202.1"
             },
-            "time": "2021-11-10T19:14:14+00:00"
+            "time": "2021-11-11T19:15:25+00:00"
         },
         {
             "name": "brick/math",
@@ -59983,24 +59983,26 @@
         },
         {
             "name": "jetbrains/phpstorm-stubs",
-            "version": "v2019.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "883b6facd78e01c0743b554af86fa590c2573f40"
+                "reference": "0b9ecc55170655ddc25a8ac9ffff80b9f450df06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/883b6facd78e01c0743b554af86fa590c2573f40",
-                "reference": "883b6facd78e01c0743b554af86fa590c2573f40",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/0b9ecc55170655ddc25a8ac9ffff80b9f450df06",
+                "reference": "0b9ecc55170655ddc25a8ac9ffff80b9f450df06",
                 "shasum": ""
             },
             "require-dev": {
-                "nikic/php-parser": "^4",
-                "php": "^7.1",
-                "phpdocumentor/reflection-docblock": "^4.3",
-                "phpunit/phpunit": "^7"
+                "friendsofphp/php-cs-fixer": "dev-master",
+                "nikic/php-parser": "@stable",
+                "php": "^8.0",
+                "phpdocumentor/reflection-docblock": "@stable",
+                "phpunit/phpunit": "@stable"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -60026,7 +60028,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2019-12-05T16:56:26+00:00"
+            "time": "2021-11-08T16:17:06+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -60687,33 +60689,27 @@
         },
         {
             "name": "ondrejmirtes/better-reflection",
-            "version": "4.10.0",
+            "version": "4.3.80",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ondrejmirtes/BetterReflection.git",
-                "reference": "5b4d1c53768e2a3bc32ab348752663733fd70546"
+                "reference": "56f215f08c4421f69e2d0e82096601b0b4fbaa2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ondrejmirtes/BetterReflection/zipball/5b4d1c53768e2a3bc32ab348752663733fd70546",
-                "reference": "5b4d1c53768e2a3bc32ab348752663733fd70546",
+                "url": "https://api.github.com/repos/ondrejmirtes/BetterReflection/zipball/56f215f08c4421f69e2d0e82096601b0b4fbaa2c",
+                "reference": "56f215f08c4421f69e2d0e82096601b0b4fbaa2c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "2019.3",
-                "nikic/php-parser": "^4.6.0",
-                "php": ">=7.4.1,<7.5.0",
-                "phpdocumentor/reflection-docblock": "^5.2.0",
-                "phpdocumentor/type-resolver": "^1.3.0",
-                "roave/signature": "^1.0"
+                "jetbrains/phpstorm-stubs": "dev-master#fdcc30312221ce08f3a4413588e2df4b77f843fc",
+                "nikic/php-parser": "^4.13.0",
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.1.0",
-                "infection/infection": "^0.16.4",
-                "phpstan/phpstan": "^0.12.25",
-                "phpunit/phpunit": "^9.2.6",
-                "vimeo/psalm": "3.13.1"
+                "phpstan/phpstan": "^0.12.49",
+                "phpunit/phpunit": "^7.5.18"
             },
             "suggest": {
                 "composer/composer": "Required to use the ComposerSourceLocator"
@@ -60726,7 +60722,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Roave\\BetterReflection\\": "src"
+                    "PHPStan\\BetterReflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -60757,9 +60753,9 @@
             ],
             "description": "Better Reflection - an improved code reflection API",
             "support": {
-                "source": "https://github.com/ondrejmirtes/BetterReflection/tree/4.10.0"
+                "source": "https://github.com/ondrejmirtes/BetterReflection/tree/4.3.80"
             },
-            "time": "2020-10-01T10:56:39+00:00"
+            "time": "2021-11-11T09:24:16+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -62533,16 +62529,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -62591,14 +62587,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -62606,7 +62602,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -65192,6 +65188,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "jetbrains/phpstorm-stubs": 20,
         "spryker/code-sniffer": 20,
         "spryker/docker-chromedriver": 20
     },


### PR DESCRIPTION
With this it will directly contain the necessary dependency for PHP7 and PHP8 compatibility:
  - Upgrading jetbrains/phpstorm-stubs (v2019.3 => dev-master 0b9ecc5)
  - Downgrading ondrejmirtes/better-reflection (4.10.0 => 4.3.80)

The `"prefer-stable": true` config is causing this, as this weird dev-master dependency is not getting pulled by default if not specified more verbosely.