### PR TITLE
Revert install source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1071,14 +1071,7 @@
         "platform": {
             "php": "7.4.15"
         },
-        "preferred-install": {
-            "spryker/*": "source",
-            "spryker-shop/*": "source",
-            "spryker-eco/*": "source",
-            "spryker-middleware/*": "source",
-            "spryker-sdk/*": "source",
-            "*": "dist"
-        },
+        "preferred-install": "dist",
         "use-include-path": true,
         "sort-packages": true,
         "github-protocols": [


### PR DESCRIPTION
If the tools and docs are not yet adjusted to handle this, we might have to try to revert this
Lets see how many tests break or dont run.

The alternative for the tests to run with --prefer-source would mean a significant slow-down here since it would also include the non spryker vendor packages (tons of them).
So not sure we can go that way here.