### PR TITLE
Disabled xdebug (coverage: none) to speed-up static validation. Switched-off ci error deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
                 options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Configure sysctl limits
               run: |
@@ -47,12 +47,12 @@ jobs:
                   stack-version: 7.10.0
                   port: 9200
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: '16'
 
             - name: NPM cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -63,16 +63,17 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
+                  coverage: none
                   extensions: mbstring, intl, pdo_mysql, redis
                   tools: composer:v2
 
             - name: Composer get cache directory
               id: composer-cache
               run: |
-                  echo "::set-output name=dir::$(composer config cache-files-dir)"
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Composer cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -167,7 +168,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -196,7 +197,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -225,7 +226,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -253,7 +254,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -282,7 +283,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -311,7 +312,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -339,7 +340,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -368,7 +369,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -396,7 +397,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -424,7 +425,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |
@@ -453,7 +454,7 @@ jobs:
             TRAVIS: 1
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install apt-packages
               run: |


### PR DESCRIPTION
#### Overview

- Disabled php xdebug (coverage: none) to speed up static validation (see https://github.com/spryker-shop/suite/actions/runs/4242137508/jobs/7373254313)
- updated action/* version to latest in order to use latest nodejs version
- changed composer get cache directory command to avoid deprecated set-output and set-state

After this PR is created we can compare the CI Time against last green CI i.e. https://github.com/spryker-shop/suite/actions/runs/4242137508